### PR TITLE
Update to support RGBDS v1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ default: parts_collection
 all: $(VERSIONS)
 
 clean:
-	rm -r $(BUILD) $(TARGETS) $(SYM_OUT) $(MAP_OUT) || exit 0
+	rm -rf $(BUILD) $(TARGETS) $(SYM_OUT) $(MAP_OUT) || exit 0
 
 # Support building specific versions
 # Unfortunately make has no real good way to do this dynamically from VERSIONS so we just manually set CURVERSION here to propagate to the rgbasm call

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 	* Currently relies on the rgbds overlay feature as parts are disassembled and tacked on
 * Make
 * Python 3.6 or greater, aliased to 'python3'
-* [rgbds](https://github.com/rednex/rgbds)
+* [rgbds](https://github.com/rednex/rgbds) >= 0.5.0
 
 # Make
 

--- a/game/src/common/constants.asm
+++ b/game/src/common/constants.asm
@@ -1,129 +1,129 @@
 INCLUDE "build/buffer_constants.asm"
 
-hRegJoyp           EQU $ff00
-hRegSB             EQU $ff01
-hRegSC             EQU $ff02
-hRegIF             EQU $ff0f
-hRegNR10           EQU $ff10
-hRegNR11           EQU $ff11
-hRegNR12           EQU $ff12
-hRegNR13           EQU $ff13
-hRegNR14           EQU $ff14
-hRegNR21           EQU $ff16
-hRegNR22           EQU $ff17
-hRegNR23           EQU $ff18
-hRegNR24           EQU $ff19
-hRegNR30           EQU $ff1a
-hRegNR31           EQU $ff1b
-hRegNR32           EQU $ff1c
-hRegNR33           EQU $ff1d
-hRegNR34           EQU $ff1e
-hRegNR41           EQU $ff20
-hRegNR42           EQU $ff21
-hRegNR43           EQU $ff22
-hRegNR44           EQU $ff23
-hRegNR50           EQU $ff24
-hRegNR51           EQU $ff25
-hRegNR52           EQU $ff26
-hRegLCDC           EQU $ff40
-hLCDStat           EQU $ff41
-hRegSCY            EQU $ff42
-hRegSCX            EQU $ff43
-hRegLY             EQU $ff44
-hRegLYC            EQU $ff45
-hRegDMA            EQU $ff46
-hRegBGP            EQU $ff47
-hRegOBP0           EQU $ff48
-hRegOBP1           EQU $ff49
-hRegWY             EQU $ff4a
-hRegWX             EQU $ff4b
-hRegKEY1           EQU $ff4d
-hRegVBK            EQU $ff4f
-hRegRP             EQU $ff56
-hRegBGPI           EQU $ff68
-hRegBGPD           EQU $ff69
-hRegOBPI           EQU $ff6a
-hRegOBPD           EQU $ff6b
-hRegSVBK           EQU $ff70
-hRegIE             EQU $ffff
+DEF    hRegJoyp           EQU $ff00
+DEF    hRegSB             EQU $ff01
+DEF    hRegSC             EQU $ff02
+DEF    hRegIF             EQU $ff0f
+DEF    hRegNR10           EQU $ff10
+DEF    hRegNR11           EQU $ff11
+DEF    hRegNR12           EQU $ff12
+DEF    hRegNR13           EQU $ff13
+DEF    hRegNR14           EQU $ff14
+DEF    hRegNR21           EQU $ff16
+DEF    hRegNR22           EQU $ff17
+DEF    hRegNR23           EQU $ff18
+DEF    hRegNR24           EQU $ff19
+DEF    hRegNR30           EQU $ff1a
+DEF    hRegNR31           EQU $ff1b
+DEF    hRegNR32           EQU $ff1c
+DEF    hRegNR33           EQU $ff1d
+DEF    hRegNR34           EQU $ff1e
+DEF    hRegNR41           EQU $ff20
+DEF    hRegNR42           EQU $ff21
+DEF    hRegNR43           EQU $ff22
+DEF    hRegNR44           EQU $ff23
+DEF    hRegNR50           EQU $ff24
+DEF    hRegNR51           EQU $ff25
+DEF    hRegNR52           EQU $ff26
+DEF    hRegLCDC           EQU $ff40
+DEF    hLCDStat           EQU $ff41
+DEF    hRegSCY            EQU $ff42
+DEF    hRegSCX            EQU $ff43
+DEF    hRegLY             EQU $ff44
+DEF    hRegLYC            EQU $ff45
+DEF    hRegDMA            EQU $ff46
+DEF    hRegBGP            EQU $ff47
+DEF    hRegOBP0           EQU $ff48
+DEF    hRegOBP1           EQU $ff49
+DEF    hRegWY             EQU $ff4a
+DEF    hRegWX             EQU $ff4b
+DEF    hRegKEY1           EQU $ff4d
+DEF    hRegVBK            EQU $ff4f
+DEF    hRegRP             EQU $ff56
+DEF    hRegBGPI           EQU $ff68
+DEF    hRegBGPD           EQU $ff69
+DEF    hRegOBPI           EQU $ff6a
+DEF    hRegOBPD           EQU $ff6b
+DEF    hRegSVBK           EQU $ff70
+DEF    hRegIE             EQU $ffff
 
-hPushOAM           EQU $ff80
+DEF    hPushOAM           EQU $ff80
 
-hBuffer            EQU $ff8b
+DEF    hBuffer            EQU $ff8b
 
-hRTCDayHi          EQU $ff8d
-hRTCDayLo          EQU $ff8e
-hRTCHours          EQU $ff8f
-hRTCMinutes        EQU $ff90
-hRTCSeconds        EQU $ff91
+DEF    hRTCDayHi          EQU $ff8d
+DEF    hRTCDayLo          EQU $ff8e
+DEF    hRTCHours          EQU $ff8f
+DEF    hRTCMinutes        EQU $ff90
+DEF    hRTCSeconds        EQU $ff91
 
-hHours             EQU $ff94
+DEF    hHours             EQU $ff94
 
-hMinutes           EQU $ff96
+DEF    hMinutes           EQU $ff96
 
-hSeconds           EQU $ff98
+DEF    hSeconds           EQU $ff98
 
-hROMBank           EQU $ff9d
+DEF    hROMBank           EQU $ff9d
 
-hJoypadReleased    EQU $ffa2
-hJoypadPressed     EQU $ffa3
-hJoypadDown        EQU $ffa4
-hJoypadSum         EQU $ffa5
-hJoyReleased       EQU $ffa6
-hJoyPressed        EQU $ffa7
-hJoyDown           EQU $ffa8
+DEF    hJoypadReleased    EQU $ffa2
+DEF    hJoypadPressed     EQU $ffa3
+DEF    hJoypadDown        EQU $ffa4
+DEF    hJoypadSum         EQU $ffa5
+DEF    hJoyReleased       EQU $ffa6
+DEF    hJoyPressed        EQU $ffa7
+DEF    hJoyDown           EQU $ffa8
 
-hPastLeadingZeroes EQU $ffb3
+DEF    hPastLeadingZeroes EQU $ffb3
 
-hDividend          EQU $ffb3
-hDivisor           EQU $ffb7
-hQuotient          EQU $ffb4
+DEF    hDividend          EQU $ffb3
+DEF    hDivisor           EQU $ffb7
+DEF    hQuotient          EQU $ffb4
 
-hMultiplicand      EQU $ffb4
-hMultiplier        EQU $ffb7
-hProduct           EQU $ffb3
+DEF    hMultiplicand      EQU $ffb4
+DEF    hMultiplier        EQU $ffb7
+DEF    hProduct           EQU $ffb3
 
-hMathBuffer        EQU $ffb8
+DEF    hMathBuffer        EQU $ffb8
 
-hLCDStatCustom     EQU $ffc6
+DEF    hLCDStatCustom     EQU $ffc6
 
-hBGMapMode         EQU $ffd4
-hBGMapThird        EQU $ffd5
-hBGMapAddress      EQU $ffd6
+DEF    hBGMapMode         EQU $ffd4
+DEF    hBGMapThird        EQU $ffd5
+DEF    hBGMapAddress      EQU $ffd6
 
-hOAMUpdate         EQU $ffd8
-hSPBuffer          EQU $ffd9
+DEF    hOAMUpdate         EQU $ffd8
+DEF    hSPBuffer          EQU $ffd9
 
-hBGMapUpdate       EQU $ffdb
+DEF    hBGMapUpdate       EQU $ffdb
 
-hTileAnimFrame     EQU $ffdf
+DEF    hTileAnimFrame     EQU $ffdf
 
-hRandomAdd         EQU $ffe1
-hRandomSub         EQU $ffe2
+DEF    hRandomAdd         EQU $ffe1
+DEF    hRandomSub         EQU $ffe2
 
-hBattleTurn        EQU $ffe4
-hCGBPalUpdate      EQU $ffe5
-hCGB               EQU $ffe6
-hSGB               EQU $ffe7
-hDMATransfer       EQU $ffe8
+DEF    hBattleTurn        EQU $ffe4
+DEF    hCGBPalUpdate      EQU $ffe5
+DEF    hCGB               EQU $ffe6
+DEF    hSGB               EQU $ffe7
+DEF    hDMATransfer       EQU $ffe8
 
 ; Joypad
-hJPInputHeldDown   EQU $ff8c
-hJPInputChanged    EQU $ff8d
+DEF    hJPInputHeldDown   EQU $ff8c
+DEF    hJPInputChanged    EQU $ff8d
 
-hJPInputA          EQU $1
-hJPInputB          EQU $2
-hJPInputSelect     EQU $4
-hJPInputStart      EQU $8
-hJPInputRight      EQU $10
-hJPInputLeft       EQU $20
-hJPInputUp         EQU $40
-hJPInputDown       EQU $80
+DEF    hJPInputA          EQU $1
+DEF    hJPInputB          EQU $2
+DEF    hJPInputSelect     EQU $4
+DEF    hJPInputStart      EQU $8
+DEF    hJPInputRight      EQU $10
+DEF    hJPInputLeft       EQU $20
+DEF    hJPInputUp         EQU $40
+DEF    hJPInputDown       EQU $80
 
 ; For SGB Tilemaps.
-P1 EQU $400
-P2 EQU $800
-P3 EQU $C00
-P4 EQU $1000
-P5 EQU $1400
-P6 EQU $1800
+DEF    P1 EQU $400
+DEF    P2 EQU $800
+DEF    P3 EQU $C00
+DEF    P4 EQU $1000
+DEF    P5 EQU $1400
+DEF    P6 EQU $1800

--- a/game/src/common/macros.asm
+++ b/game/src/common/macros.asm
@@ -1,22 +1,22 @@
 ; macro for putting a byte then a word
-dbw: MACRO
+MACRO dbw
   db \1
   dw \2
   ENDM
 
 ; macro for putting a word then a byte
-dwb: MACRO
+MACRO dwb
   dw \1
   db \2
   ENDM
 
-dbww: MACRO
+MACRO dbww
   db \1
   dw \2
   dw \3
   ENDM
   
-atfline: MACRO
+MACRO atfline
   db ((((\1 % 10000) / 1000) % 4) << 6) + ((((\1 % 1000) / 100) % 4) << 4) + ((((\1 % 100) / 10) % 4) << 2) + ((\1 % 10) % 4)
   db ((((\2 % 10000) / 1000) % 4) << 6) + ((((\2 % 1000) / 100) % 4) << 4) + ((((\2 % 100) / 10) % 4) << 2) + ((\2 % 10) % 4)
   db ((((\3 % 10000) / 1000) % 4) << 6) + ((((\3 % 1000) / 100) % 4) << 4) + ((((\3 % 100) / 10) % 4) << 2) + ((\3 % 10) % 4)

--- a/game/src/core/hardware.asm
+++ b/game/src/core/hardware.asm
@@ -19,7 +19,7 @@ SECTION "WaitLCDController", ROM0[$17E1]
 WaitLCDController:: ; 17E1 (0:17E1)
   push af
 .wfb
-  ld a, [hLCDStat]
+  ldh a, [hLCDStat]
   and 2
   jr nz, .wfb
   pop af

--- a/game/src/core/irq.asm
+++ b/game/src/core/irq.asm
@@ -62,7 +62,7 @@ LCDC_Status_IRQ: ; 4D3 (0:4D3)
   ld hl, $1
   add hl, de
   ld a, [hl]
-  ld [hRegSCX], a
+  ldh [hRegSCX], a
   ld hl, $2
   add hl, de
   ld a, [hl]
@@ -72,7 +72,7 @@ LCDC_Status_IRQ: ; 4D3 (0:4D3)
   ld a, [hl]
   ld b, a
 .asm_509
-  ld a, [hRegLY]
+  ldh a, [hRegLY]
   sub b
   jr c, .asm_509
   ld hl, $3

--- a/game/src/core/irq.asm
+++ b/game/src/core/irq.asm
@@ -66,7 +66,7 @@ LCDC_Status_IRQ: ; 4D3 (0:4D3)
   ld hl, $2
   add hl, de
   ld a, [hl]
-  ld [hRegSCY], a
+  ldh [hRegSCY], a
   ld hl, $0
   add hl, de
   ld a, [hl]
@@ -83,8 +83,8 @@ LCDC_Status_IRQ: ; 4D3 (0:4D3)
 ; 0x517
 .asm_517: ; 517 (0:517)
   xor a
-  ld [hRegSCX], a
-  ld [hRegSCY], a
+  ldh [hRegSCX], a
+  ldh [hRegSCY], a
   jp .asm_549
 .asm_51f: ; 51f (0:51f)
   xor a
@@ -93,14 +93,14 @@ LCDC_Status_IRQ: ; 4D3 (0:4D3)
   ld hl, $c800
 .asm_529
   ld a, [hli]
-  ld [hRegSCX], a
+  ldh [hRegSCX], a
   ld a, $00
-  ld [hRegSCY], a
+  ldh [hRegSCY], a
   ld a, [$c7fc]
   ld b, a
 .asm_534
   call WaitLCDController
-  ld a, [hRegLY]
+  ldh a, [hRegLY]
   sub b
   jr c, .asm_534
   ld a, [$c7fc]

--- a/game/src/core/main.asm
+++ b/game/src/core/main.asm
@@ -54,19 +54,19 @@ Main::
   call $17ea
   ld a, $83
   ld [$c5a9], a
-  ld [hRegLCDC], a
+  ldh [hRegLCDC], a
   xor a
-  ld [hRegIF], a
+  ldh [hRegIF], a
   ld a, $d
-  ld [hRegIE], a
+  ldh [hRegIE], a
   ei
   call $3c4c
   ld a, $40
-  ld [hLCDStat], a
+  ldh [hLCDStat], a
   xor a
-  ld [hRegIF], a
+  ldh [hRegIF], a
   ld a, $b
-  ld [hRegIE], a
+  ldh [hRegIE], a
   ld a, BANK(SGB_DetectICDPresence)
   ld [$c6e0], a
   rst $10

--- a/game/src/core/main.asm
+++ b/game/src/core/main.asm
@@ -8,8 +8,8 @@ Main::
 
 ; Disable all interrupts
   xor a
-  ld [hRegIF], a
-  ld [hRegIE], a
+  ldh [hRegIF], a
+  ldh [hRegIE], a
   ld sp, $fffe
 
 ; Enable SRAM

--- a/game/src/core/rst.asm
+++ b/game/src/core/rst.asm
@@ -29,7 +29,7 @@ SECTION "rst20",ROM0[$20]
 SECTION "rst28",ROM0[$28] ; hl += a
   add l
   ld l, a
-  ret nc 
+  ret nc
   inc h
   ret
 

--- a/game/src/gfx/sgb.asm
+++ b/game/src/gfx/sgb.asm
@@ -158,9 +158,9 @@ SGB_SendPackets::
   push bc
 
   ld a, 0
-  ld [c], a
+  ldh [c], a
   ld a, $30
-  ld [c], a
+  ldh [c], a
 
   ld b, $10
 
@@ -179,10 +179,10 @@ SGB_SendPackets::
   ld a, $20
 
 .sendOneBit
-  ld [c], a
+  ldh [c], a
 
   ld a, $30
-  ld [c], a
+  ldh [c], a
 
   rr d
   dec e
@@ -192,9 +192,9 @@ SGB_SendPackets::
   jr nz, .beginByte
 
   ld a, $20
-  ld [c], a
+  ldh [c], a
   ld a, $30
-  ld [c], a
+  ldh [c], a
 
   pop bc
   dec b

--- a/game/src/text/control_codes.asm
+++ b/game/src/text/control_codes.asm
@@ -4,10 +4,10 @@ Char4F:: ; 1d6b end of text
   ld a, [hl]
   or a
   jp nz, .Char4fMore
-  ld a, [$ff8d]
+  ldh a, [$ff8d]
   and $3
   jr nz, .asm_1d8b
-  ld a, [$ff8c]
+  ldh a, [$ff8c]
   and $3
   jr z, .asm_1d89
   ld a, [$c6c5]
@@ -21,7 +21,7 @@ Char4F:: ; 1d6b end of text
 
 .asm_1d8b
   ld a, $22
-  ld [$ffa1], a
+  ldh [$ffa1], a
   xor a
   ld [$c5c7], a
   ld [$c6c5], a
@@ -47,10 +47,10 @@ Char4F:: ; 1d6b end of text
   ld a, [hl]
   cp $2
   jr nz, .asm_1de4
-  ld a, [$ff8d]
+  ldh a, [$ff8d]
   and $3
   jr nz, .asm_1dd5
-  ld a, [$ff8c]
+  ldh a, [$ff8c]
   and $3
   jr z, .asm_1d89
   ld a, [$c6c5]
@@ -62,7 +62,7 @@ Char4F:: ; 1d6b end of text
   ret
 .asm_1dd5
   ld a, $22
-  ld [$ffa1], a
+  ldh [$ffa1], a
   xor a
   ld [$c6c5], a
   ld a, $1
@@ -73,10 +73,10 @@ Char4F:: ; 1d6b end of text
   ld a, [hl]
   cp $3
   jr nz, .asm_1e1b
-  ld a, [$ff8d]
+  ldh a, [$ff8d]
   and $3
   jr nz, .asm_1e03
-  ld a, [$ff8c]
+  ldh a, [$ff8c]
   and $3
   jr z, .asm_1d89
   ld a, [$c6c5]
@@ -88,7 +88,7 @@ Char4F:: ; 1d6b end of text
   ret
 .asm_1e03
   ld a, $22
-  ld [$ffa1], a
+  ldh [$ffa1], a
   ld b, $1
   ld c, $1
   ld e, $2f
@@ -156,10 +156,10 @@ Char4C::
   call WaitLCDController
   ld [hl], a
   ei
-  ld a, [$ff8d]
+  ldh a, [$ff8d]
   and $3
   jr nz, .asm_1e94
-  ld a, [$ff8c]
+  ldh a, [$ff8c]
   and $3
   ret z
   ld a, [$c6c5]
@@ -170,7 +170,7 @@ Char4C::
   ret
 .asm_1e94
   ld a, $22
-  ld [$ffa1], a
+  ldh [$ffa1], a
   xor a
   ld [$c6c5], a
   ld b, $1

--- a/game/src/text/write_text.asm
+++ b/game/src/text/write_text.asm
@@ -160,12 +160,12 @@ WriteChar:: ; 206F
   jp PutCharLoop
 .undumpedtable
 
-hPSTextAddrHi          EQU $c640
-hPSTextAddrLo          EQU $c641
-hPSVRAMAddrHi          EQU $c642
-hPSVRAMAddrLo          EQU $c643
-hPSCurrChar            EQU $c64e
-hPSCurrCharTile        EQU $c64f
+DEF    hPSTextAddrHi          EQU $c640
+DEF    hPSTextAddrLo          EQU $c641
+DEF    hPSVRAMAddrHi          EQU $c642
+DEF    hPSVRAMAddrLo          EQU $c643
+DEF    hPSCurrChar            EQU $c64e
+DEF    hPSCurrCharTile        EQU $c64f
 SECTION "PutString", ROM0[$2D93]
 PutString:: ; 2D93
   ld a, h

--- a/scripts/dialogbin2asm.py
+++ b/scripts/dialogbin2asm.py
@@ -47,4 +47,4 @@ for input_file in input_files:
 
 with open(output_file, 'w') as output:
     for k in bin_files:
-        output.write(f'c{k}        EQUS "\\"{bin_files[k]}\\""\n')
+        output.write(f'DEF    c{k}        EQUS "\\"{bin_files[k]}\\""\n')

--- a/scripts/ptrs2asm.py
+++ b/scripts/ptrs2asm.py
@@ -9,4 +9,4 @@ input_file = sys.argv[2]
 with open(output_file, 'w') as f:
     t = utils.read_table(input_file, keystring=True)
     for k in t:
-        f.write("c{:<5}           EQU ${:04X}\n".format(k, int(t[k],16)))
+        f.write("DEF    c{:<5}           EQU ${:04X}\n".format(k, int(t[k],16)))


### PR DESCRIPTION
RGBDS has seen a number of updates since 0.4.1 (the base used currently for Parts Collection).

This PR attempts to resolve breaking changes introduced by RGBDS as listed [here](https://rgbds.gbdev.io/docs/v1.0.1/rgbasm-old.5) in order to allow the project to build using the latest version.

Specific Changes:

- [Macro definition updates](https://rgbds.gbdev.io/docs/v1.0.1/rgbasm-old.5#Defining_macros_like_labels)
- Remove reliance on [`rgbasm` auto optimization of `ld`](https://rgbds.gbdev.io/docs/v1.0.1/rgbasm-old.5#Automatic_LD_to_LDH_conversion_(rgbasm_-l))
- Update [constant and variable definitions](https://rgbds.gbdev.io/docs/v1.0.1/rgbasm-old.5#Defining_constants_and_variables_without_DEF)
- Optimize [`ld [c], a` calls](https://rgbds.gbdev.io/docs/v1.0.1/rgbasm-old.5#LD__C_,_A_and_LD_A,__C_)

The contents of this PR are almost exactly the same as that of [medarot1#203](https://github.com/Medabots/medarot1/pull/203).